### PR TITLE
Enable local storage and IndexedDB on Android.

### DIFF
--- a/native_extension/ane/docs/com.tuarua.webview.xml
+++ b/native_extension/ane/docs/com.tuarua.webview.xml
@@ -243,6 +243,14 @@ using the "remote-debugging-port" command-line switch.</p>
      Sets whether Geolocation is enabled.
      </shortdesc><prolog/><apiValueDetail><apiValueDef><apiProperty/><apiAccess value="public"/><apiDynamic/><apiData>false</apiData><apiType value="Boolean"/></apiValueDef><apiDesc>
      <p>Sets whether Geolocation is enabled.</p>
+     </apiDesc></apiValueDetail></apiValue><apiValue id="com.tuarua.webview:AndroidSettings:databaseEnabled"><apiName>databaseEnabled</apiName><shortdesc>
+     Sets whether the database storage API is enabled.
+     </shortdesc><prolog/><apiValueDetail><apiValueDef><apiProperty/><apiAccess value="public"/><apiDynamic/><apiData>true</apiData><apiType value="Boolean"/></apiValueDef><apiDesc>
+     <p>Sets whether the database storage API is enabled.</p>
+     </apiDesc></apiValueDetail></apiValue><apiValue id="com.tuarua.webview:AndroidSettings:domStorageEnabled"><apiName>domStorageEnabled</apiName><shortdesc>
+     Sets whether the database storage API is enabled.
+     </shortdesc><prolog/><apiValueDetail><apiValueDef><apiProperty/><apiAccess value="public"/><apiDynamic/><apiData>true</apiData><apiType value="Boolean"/></apiValueDef><apiDesc>
+     <p>Sets whether the database storage API is enabled.</p>
      </apiDesc></apiValueDetail></apiValue><apiValue id="com.tuarua.webview:AndroidSettings:javaScriptCanOpenWindowsAutomatically"><apiName>javaScriptCanOpenWindowsAutomatically</apiName><shortdesc>
      A Boolean value indicating whether JavaScript can open windows without user interaction.
      </shortdesc><prolog/><apiValueDetail><apiValueDef><apiProperty/><apiAccess value="public"/><apiDynamic/><apiData>true</apiData><apiType value="Boolean"/></apiValueDef><apiDesc>

--- a/native_extension/src/com/tuarua/webview/AndroidSettings.as
+++ b/native_extension/src/com/tuarua/webview/AndroidSettings.as
@@ -68,6 +68,17 @@ public class AndroidSettings {
      */
     public var geolocationEnabled:Boolean = false;
 
+    /**
+     * <p>Sets whether the database storage API is enabled.</p>
+     */
+    public var databaseEnabled:Boolean = true;
+
+    /**
+     * <p>Sets whether the DOM storage API is enabled.</p>
+     */
+    public var domStorageEnabled:Boolean = true;
+    
+
     public function AndroidSettings() {
     }
 }

--- a/native_library/android/WebViewANE/app/src/main/java/com/tuarua/webviewane/Settings.kt
+++ b/native_library/android/WebViewANE/app/src/main/java/com/tuarua/webviewane/Settings.kt
@@ -40,6 +40,8 @@ class Settings() {
     var allowUniversalAccessFromFileURLs: Boolean = true
     var allowFileAccessFromFileURLs: Boolean = true
     var geolocationEnabled: Boolean = false
+    var databaseEnabled: Boolean = false
+    var domStorageEnabled: Boolean = false
     var whiteList: ArrayList<String>? = null
     var blackList: ArrayList<String>? = null
 
@@ -57,6 +59,9 @@ class Settings() {
         this.allowUniversalAccessFromFileURLs = Boolean(androidSettings?.getProperty("allowUniversalAccessFromFileURLs")) == true
         this.allowFileAccessFromFileURLs = Boolean(androidSettings?.getProperty("allowFileAccessFromFileURLs")) == true
         this.geolocationEnabled = Boolean(androidSettings?.getProperty("geolocationEnabled")) == true
+        this.databaseEnabled = Boolean(androidSettings?.getProperty("databaseEnabled")) == true
+        this.domStorageEnabled = Boolean(androidSettings?.getProperty("domStorageEnabled")) == true
+
         this.userAgent = String(o.getProperty("userAgent"))
 
         val whiteListFreK = o.getProperty("urlWhiteList")

--- a/native_library/android/WebViewANE/app/src/main/java/com/tuarua/webviewane/WebViewController.kt
+++ b/native_library/android/WebViewANE/app/src/main/java/com/tuarua/webviewane/WebViewController.kt
@@ -97,7 +97,9 @@ class WebViewController(override var context: FREContext?, initialUrl: String?, 
         wv.settings.allowContentAccess = settings.allowContentAccess
         wv.settings.allowUniversalAccessFromFileURLs = settings.allowUniversalAccessFromFileURLs
         wv.settings.allowFileAccessFromFileURLs = settings.allowFileAccessFromFileURLs
-        wv.settings.setGeolocationEnabled(false)
+        wv.settings.setGeolocationEnabled(settings.geolocationEnabled)
+        wv.settings.setDatabaseEnabled(settings.databaseEnabled)
+        wv.settings.setDomStorageEnabled(settings.domStorageEnabled)
 
         chromeClient = ChromeClient(ctx)
         viewClient = ViewClient(ctx, settings)


### PR DESCRIPTION
Hi @tuarua,

Here is my little patch that enables `localStorage` and IndexedDB on Android.
This will make the web-view match the behavior of AIR's StageWebView.

Also, I fixed hard-coded `false` value for `wv.settings.setGeolocationEnabled`. Now it gets it from `settings`.

Thanks!